### PR TITLE
Remove Equatable Requirement on Actions

### DIFF
--- a/Sources/TestingExtensions/UseCaseTests.swift
+++ b/Sources/TestingExtensions/UseCaseTests.swift
@@ -12,19 +12,59 @@ import Foundation
 @testable import SwiftRex
 import XCTest
 
+public struct SendStep<ActionType, StateType> {
+    public init(
+        action: ActionType,
+        file: StaticString = #file,
+        line: UInt = #line,
+        stateChange: @escaping (inout StateType) -> Void = { _ in }
+    ) {
+        self.action = action
+        self.file = file
+        self.line = line
+        self.stateChange = stateChange
+    }
+
+    let action: ActionType
+    let file: StaticString
+    let line: UInt
+    let stateChange: (inout StateType) -> Void
+}
+
+public struct ReceiveStep<ActionType, StateType> {
+    public init(isExpectedAction: @escaping (ActionType) -> Bool,
+                file: StaticString = #file,
+                line: UInt = #line,
+                stateChange: @escaping (inout StateType) -> Void = { _ in }) {
+        self.isExpectedAction = isExpectedAction
+        self.file = file
+        self.line = line
+        self.stateChange = stateChange
+    }
+
+    public init(action: ActionType,
+                file: StaticString = #file,
+                line: UInt = #line,
+                stateChange: @escaping (inout StateType) -> Void = { _ in }
+    ) where ActionType: Equatable {
+        self.init(
+            isExpectedAction: { $0 == action },
+            file: file,
+            line: line,
+            stateChange: stateChange
+        )
+    }
+
+    let file: StaticString
+    let line: UInt
+    let stateChange: (inout StateType) -> Void
+
+    let isExpectedAction: (ActionType) -> Bool
+}
+
 public enum Step<ActionType, StateType> {
-    case send(
-        ActionType,
-        file: StaticString = #file,
-        line: UInt = #line,
-        stateChange: (inout StateType) -> Void = { _ in }
-    )
-    case receive(
-        ActionType,
-        file: StaticString = #file,
-        line: UInt = #line,
-        stateChange: (inout StateType) -> Void = { _ in }
-    )
+    case send(SendStep<ActionType, StateType>)
+    case receive(ReceiveStep<ActionType, StateType>)
     case sideEffectResult(
         do: () -> Void
     )
@@ -39,7 +79,7 @@ extension XCTestCase {
         otherSteps: [Step<M.InputActionType, M.StateType>] = [],
         file: StaticString = #filePath,
         line: UInt = #line
-    ) where M.InputActionType == M.OutputActionType, M.InputActionType: Equatable, M.StateType: Equatable {
+    ) where M.InputActionType == M.OutputActionType, M.StateType: Equatable {
         assert(
             initialValue: initialValue,
             reducer: reducer,
@@ -60,7 +100,7 @@ extension XCTestCase {
         stateEquating: (M.StateType, M.StateType) -> Bool,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) where M.InputActionType == M.OutputActionType, M.InputActionType: Equatable {
+    ) where M.InputActionType == M.OutputActionType {
         assert(
             initialValue: initialValue,
             reducer: reducer,
@@ -80,7 +120,7 @@ extension XCTestCase {
         stateEquating: (M.StateType, M.StateType) -> Bool,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) where M.InputActionType == M.OutputActionType, M.InputActionType: Equatable {
+    ) where M.InputActionType == M.OutputActionType {
         var state = initialValue
         var middlewareResponses: [M.OutputActionType] = []
         let gotAction = XCTestExpectation(description: "got action")
@@ -95,23 +135,31 @@ extension XCTestCase {
             var expected = state
 
             switch step {
-            case let .send(action, file, line, stateChange):
+            case let .send(step)://action, file, line, stateChange):
+                let file = step.file
+                let line = step.line
+                let stateChange = step.stateChange
+
                 if !middlewareResponses.isEmpty {
                     XCTFail("Action sent before handling \(middlewareResponses.count) pending effect(s)", file: file, line: line)
                 }
 
                 var afterReducer: AfterReducer = .doNothing()
                 middleware.handle(
-                    action: action,
+                    action: step.action,
                     from: .init(file: "\(file)", function: "", line: line, info: nil),
                     afterReducer: &afterReducer
                 )
-                reducer.reduce(action, &state)
+                reducer.reduce(step.action, &state)
                 afterReducer.reducerIsDone()
 
                 stateChange(&expected)
                 ensureStateMutation(equating: stateEquating, statusQuo: state, expected: expected)
-            case let .receive(action, file, line, stateChange):
+            case let .receive(step)://action, file, line, stateChange):
+                let file = step.file
+                let line = step.line
+                let stateChange = step.stateChange
+
                 if middlewareResponses.isEmpty {
                     _ = XCTWaiter.wait(for: [gotAction], timeout: 0.2)
                 }
@@ -120,15 +168,15 @@ extension XCTestCase {
                     break
                 }
                 let first = middlewareResponses.removeFirst()
-                XCTAssertEqual(first, action, file: file, line: line)
+                XCTAssertTrue(step.isExpectedAction(first), file: file, line: line)
 
                 var afterReducer: AfterReducer = .doNothing()
                 middleware.handle(
-                    action: action,
+                    action: first,
                     from: .init(file: "\(file)", function: "", line: line, info: nil),
                     afterReducer: &afterReducer
                 )
-                reducer.reduce(action, &state)
+                reducer.reduce(first, &state)
                 afterReducer.reducerIsDone()
 
                 stateChange(&expected)


### PR DESCRIPTION
This wraps the `Step`'s associated values in structs. **This is a breaking change**.

Also included are `@autoClosure` actions so that everything is evaluated lazy during the tests, and a small debugging helper in the assert message.