### PR TITLE
Modernize snapshots

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "TestingExtensionsDynamic", type: .dynamic, targets: ["TestingExtensions"])
     ],
     dependencies: [
-        .package(name: "swift-snapshot-testing", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .upToNextMajor(from: "1.10.0")),
+        .package(name: "swift-snapshot-testing", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .upToNextMajor(from: "1.12.0")),
         .package(name: "SwiftRex", url: "https://github.com/SwiftRex/SwiftRex.git", .upToNextMajor(from: "0.8.12"))
     ],
     targets: [

--- a/Sources/TestingExtensions/SnapshotTestBase.swift
+++ b/Sources/TestingExtensions/SnapshotTestBase.swift
@@ -22,8 +22,8 @@ open class SnapshotTestBase: XCTestCase {
 
     open var defaultDevices: [(name: String, device: ViewImageConfig)] {
         [
-            ("SE", .iPhoneSe),
-            ("X", .iPhoneX),
+            ("iPhone8", .iPhone8),
+            ("iPhone13proMax", .iPhone13ProMax),
             ("iPadMini", .iPadMini(.portrait) ),
             ("iPadPro", .iPadPro12_9(.portrait))
         ]
@@ -56,7 +56,7 @@ open class SnapshotTestBase: XCTestCase {
                 }
 
                 assertSnapshot(
-                    matching: vc,
+                    of: vc,
                     as: .image(on: config.device, precision: imageDiffPrecision),
                     file: file,
                     testName: "\(testName)-\(config.name)\(suffix)",


### PR DESCRIPTION
- Drop iPhone SE 1 (breaking change!), switch default phone devices to 13pro+13proMax
- adopt new SnapshotTesting API